### PR TITLE
Darkmode fix

### DIFF
--- a/FuelMeDriver/scripts/templates/RideDriverEnterprise-Info.plist.template
+++ b/FuelMeDriver/scripts/templates/RideDriverEnterprise-Info.plist.template
@@ -177,6 +177,8 @@
 	<string>Main</string>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UIStatusBarTintParameters</key>
 	<dict>
 		<key>UINavigationBar</key>


### PR DESCRIPTION
# Why?

To restrict only to Light mode 

# What?

Added the UIUserInterfaceStyle key with value Light  
[Reference](https://developer.apple.com/documentation/xcode/supporting_dark_mode_in_your_interface/choosing_a_specific_interface_style_for_your_ios_app)