### PR TITLE
Update third party libraries

### DIFF
--- a/FuelMeDriver/RideDriver.xcodeproj/project.pbxproj
+++ b/FuelMeDriver/RideDriver.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 
 /* Begin PBXFileReference section */
 		04E27C54612BB067BDB5ABFB /* Pods-driver_pods-RideDriver - Enterprise.releaseqaenterprise.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-driver_pods-RideDriver - Enterprise.releaseqaenterprise.xcconfig"; path = "../Pods/Target Support Files/Pods-driver_pods-RideDriver - Enterprise/Pods-driver_pods-RideDriver - Enterprise.releaseqaenterprise.xcconfig"; sourceTree = "<group>"; };
-		08AF8F9999584B7931EE054C /* Pods_driver_pods_RideDriverHouston___Enterprise.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "Pods_driver_pods_RideDriverHouston___Enterprise.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		08AF8F9999584B7931EE054C /* Pods_driver_pods_RideDriverHouston___Enterprise.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_driver_pods_RideDriverHouston___Enterprise.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		09CF23D4ACFA2E3982EDF269 /* Pods-driver_pods-RideDriverTest - Enterprise.releaseenterprise.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-driver_pods-RideDriverTest - Enterprise.releaseenterprise.xcconfig"; path = "../Pods/Target Support Files/Pods-driver_pods-RideDriverTest - Enterprise/Pods-driver_pods-RideDriverTest - Enterprise.releaseenterprise.xcconfig"; sourceTree = "<group>"; };
 		1308BCCE1DDE1A04001785C3 /* ActionViewDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ActionViewDefines.h; sourceTree = "<group>"; };
 		130965751D9C55D800870914 /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
@@ -841,7 +841,7 @@
 		1D7972975FDD04FFA3392474 /* Pods-driver_pods-DriverUnitTestsSwift.releaseenterpriseqa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-driver_pods-DriverUnitTestsSwift.releaseenterpriseqa.xcconfig"; path = "../Pods/Target Support Files/Pods-driver_pods-DriverUnitTestsSwift/Pods-driver_pods-DriverUnitTestsSwift.releaseenterpriseqa.xcconfig"; sourceTree = "<group>"; };
 		246FE7FFF27A25E74F089316 /* Pods-driver_pods-DriverUnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-driver_pods-DriverUnitTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-driver_pods-DriverUnitTests/Pods-driver_pods-DriverUnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		32917304CE838FF50C3E3509 /* Pods-driver_pods-RideDriverTest - Enterprise.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-driver_pods-RideDriverTest - Enterprise.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-driver_pods-RideDriverTest - Enterprise/Pods-driver_pods-RideDriverTest - Enterprise.debug.xcconfig"; sourceTree = "<group>"; };
-		35527EBB72A6E2C2A33A3B3E /* Pods_driver_pods_RideDriver___Enterprise.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "Pods_driver_pods_RideDriver___Enterprise.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		35527EBB72A6E2C2A33A3B3E /* Pods_driver_pods_RideDriver___Enterprise.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_driver_pods_RideDriver___Enterprise.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		48A122BB3F19FF21752E7A08 /* Pods-driver_pods-RideDriverHouston - Enterprise.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-driver_pods-RideDriverHouston - Enterprise.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-driver_pods-RideDriverHouston - Enterprise/Pods-driver_pods-RideDriverHouston - Enterprise.debug.xcconfig"; sourceTree = "<group>"; };
 		4E243827C70BD5116BB24A0B /* Pods-driver_pods-DriverUnitTestsSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-driver_pods-DriverUnitTestsSwift.release.xcconfig"; path = "../Pods/Target Support Files/Pods-driver_pods-DriverUnitTestsSwift/Pods-driver_pods-DriverUnitTestsSwift.release.xcconfig"; sourceTree = "<group>"; };
 		527E850AED05CB5C31D69594 /* Pods_driver_pods_DriverUnitTestsSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_driver_pods_DriverUnitTestsSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1071,11 +1071,11 @@
 		625D50600BF93DB7256CA226 /* Pods-driver_pods-RideDriverTest - Automation.releaseenterpriseqa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-driver_pods-RideDriverTest - Automation.releaseenterpriseqa.xcconfig"; path = "../Pods/Target Support Files/Pods-driver_pods-RideDriverTest - Automation/Pods-driver_pods-RideDriverTest - Automation.releaseenterpriseqa.xcconfig"; sourceTree = "<group>"; };
 		652162D44026285CE3235CDF /* Pods-driver_pods-RideDriverTest - Enterprise.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-driver_pods-RideDriverTest - Enterprise.release.xcconfig"; path = "../Pods/Target Support Files/Pods-driver_pods-RideDriverTest - Enterprise/Pods-driver_pods-RideDriverTest - Enterprise.release.xcconfig"; sourceTree = "<group>"; };
 		666A68531DED1929A640A082 /* Pods-driver_pods-RideDriver - Enterprise.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-driver_pods-RideDriver - Enterprise.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-driver_pods-RideDriver - Enterprise/Pods-driver_pods-RideDriver - Enterprise.debug.xcconfig"; sourceTree = "<group>"; };
-		67FAFE526043795B61EC6070 /* Pods_driver_pods_RideDriverTest___Enterprise.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "Pods_driver_pods_RideDriverTest___Enterprise.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		67FAFE526043795B61EC6070 /* Pods_driver_pods_RideDriverTest___Enterprise.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_driver_pods_RideDriverTest___Enterprise.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		76BEEDE4EF738407737EEB92 /* Pods-driver_pods-RideDriverTest - Enterprise.releaseenterpriseqa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-driver_pods-RideDriverTest - Enterprise.releaseenterpriseqa.xcconfig"; path = "../Pods/Target Support Files/Pods-driver_pods-RideDriverTest - Enterprise/Pods-driver_pods-RideDriverTest - Enterprise.releaseenterpriseqa.xcconfig"; sourceTree = "<group>"; };
 		77615F16D7031ED6A1970286 /* Pods-driver_pods-DriverUnitTestsSwift.releaseqaenterprise.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-driver_pods-DriverUnitTestsSwift.releaseqaenterprise.xcconfig"; path = "../Pods/Target Support Files/Pods-driver_pods-DriverUnitTestsSwift/Pods-driver_pods-DriverUnitTestsSwift.releaseqaenterprise.xcconfig"; sourceTree = "<group>"; };
 		7A0905B9363FD52FBADBF596 /* Pods-driver_pods-RideDriverTest - Automation.releaseenterprise.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-driver_pods-RideDriverTest - Automation.releaseenterprise.xcconfig"; path = "../Pods/Target Support Files/Pods-driver_pods-RideDriverTest - Automation/Pods-driver_pods-RideDriverTest - Automation.releaseenterprise.xcconfig"; sourceTree = "<group>"; };
-		7A47F94F060147A822817DDA /* Pods_driver_pods_RideDriverTest___Automation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "Pods_driver_pods_RideDriverTest___Automation.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7A47F94F060147A822817DDA /* Pods_driver_pods_RideDriverTest___Automation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_driver_pods_RideDriverTest___Automation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8405FC401D7EF478006A8C14 /* ErrorReporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ErrorReporter.h; sourceTree = "<group>"; };
 		8405FC411D7EF478006A8C14 /* ErrorReporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ErrorReporter.m; sourceTree = "<group>"; };
 		840ABFB51F3DE2190088F77C /* ADSearchViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADSearchViewController.h; sourceTree = "<group>"; };
@@ -1493,7 +1493,7 @@
 		A0FAC45A1E311598007C5508 /* RAHelpBarView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RAHelpBarView.m; sourceTree = "<group>"; };
 		A0FAC45B1E311598007C5508 /* RAHelpBarView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RAHelpBarView.xib; sourceTree = "<group>"; };
 		AAD038F29C73F8AFAF78759C /* Pods-driver_pods-RideDriverTest - Automation.debugqa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-driver_pods-RideDriverTest - Automation.debugqa.xcconfig"; path = "../Pods/Target Support Files/Pods-driver_pods-RideDriverTest - Automation/Pods-driver_pods-RideDriverTest - Automation.debugqa.xcconfig"; sourceTree = "<group>"; };
-		AE4BBB5FA526B44EBF51EE71 /* Pods_driver_pods_RideDriverHoustonTest___Enterprise.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "Pods_driver_pods_RideDriverHoustonTest___Enterprise.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE4BBB5FA526B44EBF51EE71 /* Pods_driver_pods_RideDriverHoustonTest___Enterprise.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_driver_pods_RideDriverHoustonTest___Enterprise.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B507E6F0228F81BE0062D981 /* StringValidationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StringValidationTests.m; sourceTree = "<group>"; };
 		B52355C51D64F7460071E136 /* DailyCancelledRideCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DailyCancelledRideCell.h; path = FuelMeDriver/Classes/ViewControllers/Earnings/Cells/DailyCancelledRideCell.h; sourceTree = SOURCE_ROOT; };
 		B52355C61D64F7460071E136 /* DailyCancelledRideCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DailyCancelledRideCell.m; path = FuelMeDriver/Classes/ViewControllers/Earnings/Cells/DailyCancelledRideCell.m; sourceTree = SOURCE_ROOT; };
@@ -4608,7 +4608,7 @@
 				"${BUILT_PRODUCTS_DIR}/Mantle/Mantle.framework",
 				"${BUILT_PRODUCTS_DIR}/NSString+RemoveEmoji/NSString_RemoveEmoji.framework",
 				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs/OHHTTPStubs.framework",
-				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
+				"${BUILT_PRODUCTS_DIR}/Protobuf/protobuf.framework",
 				"${BUILT_PRODUCTS_DIR}/REFormattedNumberField/REFormattedNumberField.framework",
 				"${BUILT_PRODUCTS_DIR}/RKValueTransformers/RKValueTransformers.framework",
 				"${BUILT_PRODUCTS_DIR}/RestKit/RestKit.framework",
@@ -4642,7 +4642,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mantle.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSString_RemoveEmoji.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/protobuf.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/REFormattedNumberField.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RKValueTransformers.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RestKit.framework",
@@ -4686,7 +4686,7 @@
 				"${BUILT_PRODUCTS_DIR}/Mantle/Mantle.framework",
 				"${BUILT_PRODUCTS_DIR}/NSString+RemoveEmoji/NSString_RemoveEmoji.framework",
 				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs/OHHTTPStubs.framework",
-				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
+				"${BUILT_PRODUCTS_DIR}/Protobuf/protobuf.framework",
 				"${BUILT_PRODUCTS_DIR}/REFormattedNumberField/REFormattedNumberField.framework",
 				"${BUILT_PRODUCTS_DIR}/RKValueTransformers/RKValueTransformers.framework",
 				"${BUILT_PRODUCTS_DIR}/RestKit/RestKit.framework",
@@ -4720,7 +4720,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mantle.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSString_RemoveEmoji.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/protobuf.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/REFormattedNumberField.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RKValueTransformers.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RestKit.framework",
@@ -4862,7 +4862,7 @@
 				"${BUILT_PRODUCTS_DIR}/Mantle/Mantle.framework",
 				"${BUILT_PRODUCTS_DIR}/NSString+RemoveEmoji/NSString_RemoveEmoji.framework",
 				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs/OHHTTPStubs.framework",
-				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
+				"${BUILT_PRODUCTS_DIR}/Protobuf/protobuf.framework",
 				"${BUILT_PRODUCTS_DIR}/REFormattedNumberField/REFormattedNumberField.framework",
 				"${BUILT_PRODUCTS_DIR}/RKValueTransformers/RKValueTransformers.framework",
 				"${BUILT_PRODUCTS_DIR}/RestKit/RestKit.framework",
@@ -4896,7 +4896,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mantle.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSString_RemoveEmoji.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/protobuf.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/REFormattedNumberField.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RKValueTransformers.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RestKit.framework",

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,72 +17,87 @@ PODS:
     - FBSDKCoreKit
   - FBSDKShareKit (4.44.1):
     - FBSDKCoreKit
-  - Firebase/Analytics (6.5.0):
+  - Firebase/Analytics (6.12.0):
     - Firebase/Core
-  - Firebase/Core (6.5.0):
+  - Firebase/Core (6.12.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 6.0.4)
-  - Firebase/CoreOnly (6.5.0):
-    - FirebaseCore (= 6.1.0)
-  - Firebase/InAppMessagingDisplay (6.5.0):
+    - FirebaseAnalytics (= 6.1.5)
+  - Firebase/CoreOnly (6.12.0):
+    - FirebaseCore (= 6.3.3)
+  - Firebase/InAppMessagingDisplay (6.12.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessagingDisplay (~> 0.15.2)
-  - Firebase/Messaging (6.5.0):
+    - FirebaseInAppMessagingDisplay (~> 0.15.5)
+  - Firebase/Messaging (6.12.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 4.1.1)
-  - Firebase/RemoteConfig (6.5.0):
+    - FirebaseMessaging (~> 4.1.8)
+  - Firebase/RemoteConfig (6.12.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 4.2.1)
-  - FirebaseABTesting (3.1.1):
+    - FirebaseRemoteConfig (~> 4.4.4)
+  - FirebaseABTesting (3.1.2):
     - FirebaseAnalyticsInterop (~> 1.3)
     - FirebaseCore (~> 6.1)
-    - Protobuf (~> 3.8)
-  - FirebaseAnalytics (6.0.4):
-    - FirebaseCore (~> 6.1)
+    - Protobuf (>= 3.9.2, ~> 3.9)
+  - FirebaseAnalytics (6.1.5):
+    - FirebaseCore (~> 6.3)
     - FirebaseInstanceID (~> 4.2)
-    - GoogleAppMeasurement (= 6.0.4)
+    - GoogleAppMeasurement (= 6.1.5)
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
-    - nanopb (~> 0.3)
+    - nanopb (= 0.3.9011)
   - FirebaseAnalyticsInterop (1.4.0)
-  - FirebaseCore (6.1.0):
-    - GoogleUtilities/Environment (~> 6.0)
-    - GoogleUtilities/Logger (~> 6.0)
-  - FirebaseInAppMessaging (0.15.2):
-    - FirebaseAnalyticsInterop (~> 1.2)
-    - FirebaseCore (~> 6.0)
+  - FirebaseCore (6.3.3):
+    - FirebaseCoreDiagnostics (~> 1.0)
+    - FirebaseCoreDiagnosticsInterop (~> 1.0)
+    - GoogleUtilities/Environment (~> 6.2)
+    - GoogleUtilities/Logger (~> 6.2)
+  - FirebaseCoreDiagnostics (1.1.1):
+    - FirebaseCoreDiagnosticsInterop (~> 1.0)
+    - GoogleDataTransportCCTSupport (~> 1.0)
+    - GoogleUtilities/Environment (~> 6.2)
+    - GoogleUtilities/Logger (~> 6.2)
+    - nanopb (~> 0.3.901)
+  - FirebaseCoreDiagnosticsInterop (1.1.0)
+  - FirebaseInAppMessaging (0.15.5):
+    - FirebaseAnalyticsInterop (~> 1.3)
+    - FirebaseCore (~> 6.2)
     - FirebaseInstanceID (~> 4.0)
-  - FirebaseInAppMessagingDisplay (0.15.2):
-    - FirebaseCore (~> 6.0)
+    - GoogleDataTransportCCTSupport (~> 1.0)
+  - FirebaseInAppMessagingDisplay (0.15.5):
+    - FirebaseCore (~> 6.2)
     - FirebaseInAppMessaging (>= 0.15.0)
-  - FirebaseInstanceID (4.2.2):
+  - FirebaseInstanceID (4.2.7):
     - FirebaseCore (~> 6.0)
     - GoogleUtilities/Environment (~> 6.0)
     - GoogleUtilities/UserDefaults (~> 6.0)
-  - FirebaseMessaging (4.1.1):
-    - FirebaseAnalyticsInterop (~> 1.1)
-    - FirebaseCore (~> 6.0)
+  - FirebaseMessaging (4.1.8):
+    - FirebaseAnalyticsInterop (~> 1.3)
+    - FirebaseCore (~> 6.2)
     - FirebaseInstanceID (~> 4.1)
     - GoogleUtilities/AppDelegateSwizzler (~> 6.2)
     - GoogleUtilities/Environment (~> 6.2)
     - GoogleUtilities/Reachability (~> 6.2)
     - GoogleUtilities/UserDefaults (~> 6.2)
-    - Protobuf (~> 3.1)
-  - FirebaseRemoteConfig (4.2.1):
-    - FirebaseABTesting (~> 3.0)
-    - FirebaseCore (~> 6.1)
+    - Protobuf (>= 3.9.2, ~> 3.9)
+  - FirebaseRemoteConfig (4.4.4):
+    - FirebaseABTesting (~> 3.1)
+    - FirebaseAnalyticsInterop (~> 1.4)
+    - FirebaseCore (~> 6.2)
     - FirebaseInstanceID (~> 4.2)
-    - GoogleUtilities/Environment (~> 6.0)
-    - "GoogleUtilities/NSData+zlib (~> 6.0)"
-    - Protobuf (~> 3.5)
-  - GoogleAppMeasurement (6.0.4):
+    - GoogleUtilities/Environment (~> 6.2)
+    - "GoogleUtilities/NSData+zlib (~> 6.2)"
+    - Protobuf (>= 3.9.2, ~> 3.9)
+  - GoogleAppMeasurement (6.1.5):
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
-    - nanopb (~> 0.3)
+    - nanopb (= 0.3.9011)
+  - GoogleDataTransport (3.0.1)
+  - GoogleDataTransportCCTSupport (1.2.1):
+    - GoogleDataTransport (~> 3.0)
+    - nanopb (~> 0.3.901)
   - GoogleMaps (3.5.0):
     - GoogleMaps/Maps (= 3.5.0)
   - GoogleMaps/Base (3.5.0)
@@ -90,23 +105,23 @@ PODS:
     - GoogleMaps/Base
   - GooglePlaces (3.5.0):
     - GoogleMaps/Base (= 3.5.0)
-  - GoogleUtilities/AppDelegateSwizzler (6.2.3):
+  - GoogleUtilities/AppDelegateSwizzler (6.3.1):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (6.2.3)
-  - GoogleUtilities/Logger (6.2.3):
+  - GoogleUtilities/Environment (6.3.1)
+  - GoogleUtilities/Logger (6.3.1):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (6.2.3):
+  - GoogleUtilities/MethodSwizzler (6.3.1):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (6.2.3):
+  - GoogleUtilities/Network (6.3.1):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (6.2.3)"
-  - GoogleUtilities/Reachability (6.2.3):
+  - "GoogleUtilities/NSData+zlib (6.3.1)"
+  - GoogleUtilities/Reachability (6.3.1):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (6.2.3):
+  - GoogleUtilities/UserDefaults (6.3.1):
     - GoogleUtilities/Logger
   - ISO8601DateFormatterValueTransformer (0.6.1):
     - RKValueTransformers (~> 1.1.0)
@@ -116,11 +131,11 @@ PODS:
     - Mantle/extobjc (= 2.1.0)
   - Mantle/extobjc (2.1.0)
   - MRCountryPicker (0.0.8)
-  - nanopb (0.3.901):
-    - nanopb/decode (= 0.3.901)
-    - nanopb/encode (= 0.3.901)
-  - nanopb/decode (0.3.901)
-  - nanopb/encode (0.3.901)
+  - nanopb (0.3.9011):
+    - nanopb/decode (= 0.3.9011)
+    - nanopb/encode (= 0.3.9011)
+  - nanopb/decode (0.3.9011)
+  - nanopb/encode (0.3.9011)
   - "NSString+RemoveEmoji (1.1.0)"
   - OHHTTPStubs (6.1.0):
     - OHHTTPStubs/Default (= 6.1.0)
@@ -135,7 +150,7 @@ PODS:
   - OHHTTPStubs/NSURLSession (6.1.0):
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (6.1.0)
-  - Protobuf (3.9.0)
+  - Protobuf (3.10.0)
   - REFormattedNumberField (1.1.6)
   - RestKit (0.27.3):
     - RestKit/Core (= 0.27.3)
@@ -226,12 +241,16 @@ SPEC REPOS:
     - FirebaseAnalytics
     - FirebaseAnalyticsInterop
     - FirebaseCore
+    - FirebaseCoreDiagnostics
+    - FirebaseCoreDiagnosticsInterop
     - FirebaseInAppMessaging
     - FirebaseInAppMessagingDisplay
     - FirebaseInstanceID
     - FirebaseMessaging
     - FirebaseRemoteConfig
     - GoogleAppMeasurement
+    - GoogleDataTransport
+    - GoogleDataTransportCCTSupport
     - GoogleMaps
     - GooglePlaces
     - GoogleUtilities
@@ -289,28 +308,32 @@ SPEC CHECKSUMS:
   FBSDKCoreKit: a823ae35bdb60ebb8d7a7e51abe7c5d87d2bfced
   FBSDKLoginKit: 54ae59987f2a8703021557c90a9aebb9e5c2bef6
   FBSDKShareKit: 526d4cfb713d24855fa23d0dd74e191accd3a720
-  Firebase: dedc9e48ea3f3649ad5f6b982f8a0c73508a14b5
-  FirebaseABTesting: 662e8de812ceb5d57ad66381f6402f4d28dc5c91
-  FirebaseAnalytics: 3fb375bc9d13779add4039716f868d233a473fad
+  Firebase: da031bc7012374e3bed17a6731b89327b29863b9
+  FirebaseABTesting: 0d10f3cdc3fa00f3f175b5b56c1003c8e888299f
+  FirebaseAnalytics: 4e53a7eb7b76bc703c4d9239bc964545e9b23361
   FirebaseAnalyticsInterop: d48b6ab67bcf016a05e55b71fc39c61c0cb6b7f3
-  FirebaseCore: aecf02fb2274ec361b9bebeac112f5daa18273bd
-  FirebaseInAppMessaging: f67c9157099d6ed58b2229e4642ac37d0c206192
-  FirebaseInAppMessagingDisplay: a06c3bd9e52e3db9f93dd58dfb425eab33543855
-  FirebaseInstanceID: 662b8108a09fe9ed01aafdedba100fde8536b0f6
-  FirebaseMessaging: 6bb0bdaf64c55fef7a219b7bb1e94e94a0855ced
-  FirebaseRemoteConfig: ed74d16d7e5b19e77a4c3e3eee4fe363039b0834
-  GoogleAppMeasurement: 183bd916af7f80deb67c01888368f1108d641832
+  FirebaseCore: bcd6c112429249d7921e907d661e8955a3549e26
+  FirebaseCoreDiagnostics: af29e43048607588c050889d19204f4d7b758c9f
+  FirebaseCoreDiagnosticsInterop: e9b1b023157e3a2fc6418b5cb601e79b9af7b3a0
+  FirebaseInAppMessaging: acbfa8c5582b11ccc0366511d29ef1d288f302fc
+  FirebaseInAppMessagingDisplay: 60a65c8277f17675a8a5b92e9a97cd914b45d4ff
+  FirebaseInstanceID: ebd2ea79ee38db0cb5f5167b17a0d387e1cc7b6e
+  FirebaseMessaging: de30f83a372a390be6f2ba44ec43a45b7ccdb43f
+  FirebaseRemoteConfig: 8bb483b372bf859635c719d01911d5f7bf6df4b4
+  GoogleAppMeasurement: 037f46d1d8ae8b312720f1042585ab961a1289e3
+  GoogleDataTransport: 166f9b9f82cbf60a204e8fe2daa9db3e3ec1fb15
+  GoogleDataTransportCCTSupport: f6ab1962e9dc05ab1fb938b795e5b310209edeec
   GoogleMaps: 32ca02de09de357a10ac773f2c70f1986751392d
   GooglePlaces: be6f19fe8aa6ff0b5bcccfa1b8805cc977ea1450
-  GoogleUtilities: d2b0e277a95962e09bb27f5cd42f5f0b6a506c7d
+  GoogleUtilities: f895fde57977df4e0233edda0dbeac490e3703b6
   ISO8601DateFormatterValueTransformer: 52da467d6ec899d6aedda8e48280ac92e8ee97e6
   LGRefreshView: 34746afadbd23de8d1449cab15f3d89269645d43
   Mantle: 2fa750afa478cd625a94230fbf1c13462f29395b
   MRCountryPicker: 1aeea66de25cdef79dce3b91d8ad9db643c1cc01
-  nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
+  nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   "NSString+RemoveEmoji": 8bcac49d1d2ffd421fdc6582e739f2a1ea6e0fff
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
-  Protobuf: 1097ca58584c8d9be81bfbf2c5ff5975648dd87a
+  Protobuf: a4dc852ad69c027ca2166ed287b856697814375b
   REFormattedNumberField: 70fc5fb1218ebd5ee9983820defd12806d5c6ec6
   RestKit: 0baa8b61899d1e00c24f4f2d8aea07ecef0c88bc
   Result: d2d07204ce72856f1fd9130bbe42c35a7b0fea10


### PR DESCRIPTION
# What?

Installed Firebase 6.12.0 (was 6.5.0)
Installed FirebaseABTesting 3.1.2 (was 3.1.1)
Installed FirebaseAnalytics 6.1.5 (was 6.0.4)
Installed FirebaseCore 6.3.3 (was 6.1.0)
Installed FirebaseCoreDiagnostics (1.1.1)
Installed FirebaseCoreDiagnosticsInterop (1.1.0)
Installed FirebaseInAppMessaging 0.15.5 (was 0.15.2)
Installed FirebaseInAppMessagingDisplay 0.15.5 (was 0.15.2)
Installed FirebaseInstanceID 4.2.7 (was 4.2.2)
Installed FirebaseMessaging 4.1.8 (was 4.1.1)
Installed FirebaseRemoteConfig 4.4.4 (was 4.2.1)
Installed GoogleAppMeasurement 6.1.5 (was 6.0.4)
Installed GoogleDataTransport (3.0.1)
Installed GoogleDataTransportCCTSupport (1.2.1)
Installed GoogleUtilities 6.3.1 (was 6.2.3)
Installed Protobuf 3.10.0 (was 3.9.0)