### PR TITLE
Enable ability to skip SMS verification on RC

### DIFF
--- a/FuelMeDriver/FuelMeDriver/Classes/Managers/NetworkManager/ConfigAPI/UserAPI/RAUserAPI.h
+++ b/FuelMeDriver/FuelMeDriver/Classes/Managers/NetworkManager/ConfigAPI/UserAPI/RAUserAPI.h
@@ -10,7 +10,10 @@
 #import "RAUserDataModel.h"
 
 typedef void(^RAUserAPICompletionBlock)(RAUserDataModel* user, NSError *error);
+typedef void (^APICheckResponseBlock)(BOOL failed, NSError* error);
 
 @interface RAUserAPI : RABaseAPI
 + (void) updateUser:(RAUserDataModel*)user withCompletion:(RAUserAPICompletionBlock)completion;
++ (void) checkAvailabilityOfPhone:(NSString*)phoneNumber withCompletion:(APICheckResponseBlock)handler;
+
 @end

--- a/FuelMeDriver/FuelMeDriver/Classes/Managers/NetworkManager/ConfigAPI/UserAPI/RAUserAPI.m
+++ b/FuelMeDriver/FuelMeDriver/Classes/Managers/NetworkManager/ConfigAPI/UserAPI/RAUserAPI.m
@@ -9,6 +9,34 @@
 #import "RAUserAPI.h"
 
 @implementation RAUserAPI
+
++ (void)checkAvailabilityOfPhone:(NSString *)phoneNumber withCompletion:(APICheckResponseBlock)handler {
+    NSParameterAssert(phoneNumber.length > 0);
+    [RAUserAPI checkAvailabilityOfEmail:nil andPhone:phoneNumber withCompletion:handler];
+}
+
++ (void)checkAvailabilityOfEmail:(NSString *)email andPhone:(NSString *)phoneNumber withCompletion:(APICheckResponseBlock)completion {
+    NSString *path = @"users/exists";
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+    parameters[@"email"] = email;
+    parameters[@"phoneNumber"] = phoneNumber;
+    
+    AFRKHTTPClient *httpClient = [RKObjectManager sharedManager].HTTPClient.copy;
+       httpClient.parameterEncoding = AFRKJSONParameterEncoding;
+    [httpClient putPath:path parameters:parameters success:^(AFRKHTTPRequestOperation *operation, id responseObject) {
+        RAUserDataModel *model = [RAJSONAdapter modelOfClass:RAUserDataModel.class fromJSONDictionary:responseObject isNullable:NO];
+        if (completion) {
+            completion(model, nil);
+        }
+    } failure:^(AFRKHTTPRequestOperation *operation, NSError *error) {
+        [ErrorReporter recordError:error withDomainName:PUTSaveProfile];
+        NSError *raError = [error filteredErrorAtReponse:operation.response];
+        if (completion) {
+            completion(nil, raError);
+        }
+    }];
+}
+
 + (void)updateUser:(RAUserDataModel *)user withCompletion:(RAUserAPICompletionBlock)completion {
     NSMutableDictionary *params = [NSMutableDictionary new];
     params[@"email"]        = user.email;


### PR DESCRIPTION
# Why?

_When changing the phone number in the test environment it doesn't ask for the ability to skip it for RC fixes #33  ._

# What?

_Add ability to skip 2FA when changing phone number in RC._