### PR TITLE
Add identifier for location background task.

### DIFF
--- a/FuelMeDriver/scripts/templates/RideDriverEnterprise-Info.plist.template
+++ b/FuelMeDriver/scripts/templates/RideDriverEnterprise-Info.plist.template
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.driveaustin.public.location</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
# Why?

It currently blocks the appstore submission. #14 

# What?

Add identifier for location background task.
https://developer.apple.com/documentation/backgroundtasks/bgtaskscheduler