### PR TITLE
Install pods only when cache is not available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,11 @@ jobs:
       - run:
           name: Install CocoaPods
           command: |
-            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
-            bundle exec pod install
+            if [ ! -d "Pods" ]
+            then
+               curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+              bundle exec pod install
+            fi
       - save_cache:
           key: 1-pods-{{ checksum "Podfile.lock" }}
           paths:


### PR DESCRIPTION
# Why?

https://medium.com/wandercodes/how-to-save-time-in-circleci-when-using-pods-4e00cd419ad8