### PR TITLE
Remove unnecessary MKDirectionsApplicationSupportedModes

### DIFF
--- a/FuelMeDriver/scripts/templates/RideDriverEnterprise-Info.plist.template
+++ b/FuelMeDriver/scripts/templates/RideDriverEnterprise-Info.plist.template
@@ -75,10 +75,6 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>MKDirectionsApplicationSupportedModes</key>
-	<array>
-		<string>MKDirectionsModeCar</string>
-	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
# Why?

ITMS-90116: Invalid Info.plist: To include the MKDirectionsApplicationSupportedModes key in the Info.plist, you must define the app binary as a routing app.